### PR TITLE
issue #522 Add a note about the environment variables that intentionally save commands as strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Used with permission.
 
 > The `az cosmosdb sql` extension is currently in preview and is subject to change
 
-Some of the environment variables that will be created will be commands for retriving sensitive values. This is intentional to avoid saving sensitive data in environment variables. For example, `export Imdb_RW_Key='az cosmosdb keys list ...'`. Make sure to run the export commands as is to save the actual command as a string.
+Some environment variables will save commands as strings instead of running the command and saving the output. This is intentional to avoid saving sensitive data in environment variables. For example, `export Imdb_RW_Key='az cosmosdb keys list ...'`. Make sure to run the export commands as is.
 
 ```bash
 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,6 @@ Used with permission.
 
 > The `az cosmosdb sql` extension is currently in preview and is subject to change
 
-Some environment variables will save commands as strings instead of running the command and saving the output. This is intentional to avoid saving sensitive data in environment variables. For example, `export Imdb_RW_Key='az cosmosdb keys list ...'`. Make sure to run the export commands as is.
-
 ```bash
 
 # replace with a unique name
@@ -50,7 +48,18 @@ az cosmosdb check-name-exists -n ${Imdb_Name}
 export Imdb_Location="centralus"
 export Imdb_DB="imdb"
 export Imdb_Col="movies"
+
+```
+
+> This environment variable saves the command as a string instead of running the command and saving the output. This is intentional to avoid saving sensitive data in environment variables. Make sure to run the export commands as is. When the value is needed, the command will be executed with `eval`. For example, `dotnet run -- $Imdb_Name $(eval $Imdb_RW_Key) ...`.
+
+```bash
+
 export Imdb_RW_Key='az cosmosdb keys list -n $Imdb_Name -g $Imdb_RG --query primaryMasterKey -o tsv'
+
+```
+
+```bash
 
 # Resource Group Name
 export Imdb_RG=${Imdb_Name}-rg-cosmos

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Used with permission.
 
 > The `az cosmosdb sql` extension is currently in preview and is subject to change
 
+Some of the environment variables that will be created will be commands for retriving sensitive values. This is intentional to avoid saving sensitive data in environment variables. For example, `export Imdb_RW_Key='az cosmosdb keys list ...'`. Make sure to run the export commands as is to save the actual command as a string.
+
 ```bash
 
 # replace with a unique name


### PR DESCRIPTION
## Type of PR

- [x] Documentation changes
- [ ] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

### Purpose of PR

Some of the environment variables intentionally save commands as strings for use at later points in the setup process. Update the documentation to be explicit about that, so that the user does not try to run the commands too early.

helium edit: https://github.com/retaildevcrews/helium/pull/528

### Validation
- [ ] Unit tests updated and ran successfully
- [x] Update documentation or issue referenced above

### Issues Closed or Referenced

- References https://github.com/retaildevcrews/helium/issues/522
