### PR TITLE
Update deprecated set-env commands for actions to new syntax

### DIFF
--- a/.github/workflows/dockerCI.yml
+++ b/.github/workflows/dockerCI.yml
@@ -44,9 +44,9 @@ jobs:
         # check that all Docker secrets are set
         if [[ "${{ secrets.DOCKER_PAT }}" != "" && "${{ secrets.DOCKER_REPO }}" != "" && "${{ secrets.DOCKER_USER }}" != "" ]];
         then
-          echo "::set-env name=DOCKER_SET::true"
+          echo "DOCKER_SET=true" >> $GITHUB_ENV
         fi
-        
+
     - name: Docker Pull
       run: |
         # Pull the latest image if needed


### PR DESCRIPTION
## Type of PR

- [ ] Documentation changes
- [ ] Code changes
- [ ] Test changes
- [x] CI-CD changes
- [ ] GitHub Template changes

### Purpose of PR

The "set-env" syntax for setting environment variables in actions is being deprecated. Update the actions to the new way of setting env vars.

https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable

### Validation
- [ ] Unit tests updated and ran successfully
- [ ] Update documentation or issue referenced above

### Issues Closed or Referenced

- Closes retaildevcrews/helium#604
